### PR TITLE
Fix overriding local webpack config file

### DIFF
--- a/src/configure.js
+++ b/src/configure.js
@@ -92,7 +92,7 @@ export default function configure(options) {
 	}
 
 	function webpackProp(name, value) {
-		let configured = delve(webpackConfig, 'resolve.alias');
+		let configured = delve(webpackConfig, name);
 		if (Array.isArray(value)) {
 			return value.concat(configured || []).filter(dedupe);
 		}


### PR DESCRIPTION
Fixes an issue I was having with the `resolve.extensions` setting in my local `webpack.config.js` file being ignored.