### PR TITLE
Adding webpack to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Most importantly, Karmatic provides a (headless) browser test harness in a singl
 ## Installation
 
 ```sh
-npm i -D karmatic
+npm i -D webpack karmatic
 ```
 
 ... then add a `test` script to your `package.json`:


### PR DESCRIPTION
To make it clearer that webpack is a peer dependency.

Alternatively, I can add a note below the installation instructions if you prefer.