### PR TITLE
Add code coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 package-lock.json
 dist
 build
+coverage

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-polyfill": "^6.26.0",
@@ -46,6 +47,7 @@
     "jasmine-core": "^2.9.1",
     "karma": "^2.0.0",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-coverage": "^1.1.2",
     "karma-jasmine": "^1.1.1",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.32",

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,8 @@ let prog = sade('karmatic');
 prog
 	.version(version)
 	.option('--files', 'Minimatch pattern for test files')
-	.option('--headless', 'Run using Chrome Headless', true);
+	.option('--headless', 'Run using Chrome Headless', true)
+	.option('--coverage', 'Report code coverage of tests', true);
 
 prog
 	.command('run [...files]', '', { default: true })

--- a/src/configure.js
+++ b/src/configure.js
@@ -27,7 +27,9 @@ export default function configure(options) {
 		'karma-spec-reporter',
 		'karma-sourcemap-loader',
 		'karma-webpack'
-	];
+	].concat(
+		options.coverage ? 'karma-coverage' : []
+	);
 
 	const WEBPACK_CONFIGS = [
 		'webpack.config.babel.js',
@@ -109,7 +111,9 @@ export default function configure(options) {
 		basePath: cwd,
 		plugins: PLUGINS.map(require.resolve),
 		frameworks: ['jasmine'],
-		reporters: ['spec'],
+		reporters: ['spec'].concat(
+			options.coverage ? 'coverage' : []
+		),
 		browsers: [options.headless===false ? 'KarmaticChrome' : 'KarmaticChromeHeadless'],
 
 		customLaunchers: {
@@ -120,6 +124,14 @@ export default function configure(options) {
 				base: 'ChromeHeadless',
 				flags: ['--no-sandbox']
 			}
+		},
+
+		coverageReporter: {
+			reporters: [
+				{ type: 'text-summary' },
+				{ type: 'html' },
+				{ type: 'lcovonly', subdir: '.', file: 'lcov.info' }
+			]
 		},
 
 		formatError(msg) {

--- a/src/lib/babel-loader.js
+++ b/src/lib/babel-loader.js
@@ -17,7 +17,9 @@ export default function babelLoader(options) {
 			plugins: [
 				[require.resolve('babel-plugin-transform-object-rest-spread')],
 				[require.resolve('babel-plugin-transform-react-jsx'), { pragma: options.pragma || 'h' }]
-			]
+			].concat(
+				options.coverage ? require.resolve('babel-plugin-istanbul') : []
+			)
 		}
 	};
 }


### PR DESCRIPTION
Add a new `--coverage` option (defaults to `true`) to enable code coverage reporting. It instruments the code using [babel-plugin-istanbul](https://github.com/istanbuljs/babel-plugin-istanbul) by the istanbuljs team.

Closes #16 