### PR TITLE
Bump to highest minor version of karma-webpack for lodash 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-sauce-launcher": "^2.0.2",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "2.0.7",
+    "karma-webpack": "^2.0.13",
     "puppeteer": "^1.0.0",
     "sade": "^1.3.1",
     "script-loader": "^0.7.2"


### PR DESCRIPTION
Hi 👋 

Firstly, great tool so thank you very much. 

### What

This PR bumps `karma-webpack` to the highest `2.0.*` version, so that it no longer depends on lodash 3. 
See: https://github.com/webpack-contrib/karma-webpack/blob/316c6f2d42df0be5b251eb0ff605307a371c480b/package.json#L34

It looks to me that you could probably bump to v4 as the breaking changes are just minimum node and webpack versions, but I prefered to keep the changes minimal. 

### Why

Currently karmatics depends on karma-webpack 2.0.7 which depends on lodash < 4. Versions below 4 of lodash are not receiving the security fixes, and this makes it very difficult to update projects that are using karmatic so they have no high risk vulnerability packages. 

When lodash ^4.0.0 is used, `npm audit fix` can easily modify the package lock file for the new lodash security fixes. 