### PR TITLE
Only generate necessary dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"bin": "dist/cli.js",
 	"scripts": {
 		"prepare": "npm t",
-		"build": "microbundle --target node -f cjs --no-compress src/*.js",
+		"build": "microbundle --target node -f cjs --no-compress src/index.js src/cli.js",
 		"test:build": "node ./dist/cli.js run",
 		"test:watch": "node ./dist/cli.js watch --headless false",
 		"prettier": "prettier --write './**/*.{js,json,yml,md}'",


### PR DESCRIPTION
There is no need to build an entry for `appender.js` and `configure.js` as those two files are already inline in `index.js`.