### PR TITLE
Ignore native Jasmine frames in stack trace

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -105,6 +105,7 @@ export function cleanStack(str, cwd = process.cwd()) {
 	let nearestFrame;
 
 	stack = frames
+		.filter((frame) => frame.type !== 'native' || frame.name !== 'Jasmine')
 		.map((frame) => {
 			// Only show frame for errors in the user's code
 			if (


### PR DESCRIPTION
Before:

```bash
at <Jasmine>
at UserContext.<anonymous> (./foo.js:72:3 <- ./foo.js:428:3773)
at <Jasmine>
```

After:

```bash
at UserContext.<anonymous> (./foo.js:72:3 <- ./foo.js:428:3773)
```