### PR TITLE
Only build karmatic entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"bin": "dist/cli.js",
 	"scripts": {
 		"prepare": "npm t",
-		"build": "microbundle --target node -f cjs --no-compress src/*.js",
+		"build": "microbundle --target node -f cjs --no-compress src/cli.js src/index.js",
 		"test:build": "node ./dist/cli.js run",
 		"test:watch": "node ./dist/cli.js watch --headless false",
 		"prettier": "prettier --write './**/*.{js,json,yml,md}'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"bin": "dist/cli.js",
 	"scripts": {
 		"prepare": "npm t",
-		"build": "microbundle --target node -f cjs --no-compress src/cli.js src/index.js",
+		"build": "microbundle --target node -f cjs --no-compress src/index.js src/cli.js src/appender.js",
 		"test:build": "node ./dist/cli.js run",
 		"test:watch": "node ./dist/cli.js watch --headless false",
 		"prettier": "prettier --write './**/*.{js,json,yml,md}'",


### PR DESCRIPTION
If I understand correctly the only two entry points for karmatic are the cli (`cli.js`) and package main (`index.js`). So I've updated our microbundle script to only build our entrypoints. Since we are only building our entry points it cuts our package size in half.