### PR TITLE
Add coverage as a separate babel loader if loaders already exist

### DIFF
--- a/src/lib/babel-loader.js
+++ b/src/lib/babel-loader.js
@@ -1,4 +1,15 @@
-export default function babelLoader(options) {
+export function getCoverageBabelLoader() {
+	return {
+		test: /\.jsx?$/,
+		exclude: /node_modules/,
+		loader: require.resolve('babel-loader'),
+		query: {
+			plugins: [require.resolve('babel-plugin-istanbul')],
+		},
+	};
+}
+
+export function getDefaultBabelLoader(options) {
 	return {
 		test: /\.jsx?$/,
 		exclude: /node_modules/,


### PR DESCRIPTION
With the new E2E test suite, I noticed that coverage is not properly reported when the user provides a custom webpack.config.js. This PR fixes that by detecting if webpack loaders exist and if so, adding a new babel-loader with just the coverage plugin enabled.

Our tests also now enforce that coverage is correctly reported for all tests.